### PR TITLE
Bugfix when key values are mixed

### DIFF
--- a/src/PhpPresentation/Writer/PowerPoint2007/PptCharts.php
+++ b/src/PhpPresentation/Writer/PowerPoint2007/PptCharts.php
@@ -351,7 +351,12 @@ class PptCharts extends AbstractDecoratorWriter
         // c:strLit / c:numLit
         // c:strRef / c:numRef
         $referenceType = ($isReference ? 'Ref' : 'Lit');
-        $dataType = is_numeric($values[0]) ? 'num' : 'str';
+        $dataType = 'num';
+        foreach ($values as $value){
+            if (!is_numeric($value)){
+                $dataType = 'str';
+            }
+        }
         $objWriter->startElement('c:' . $dataType . $referenceType);
 
         $numValues = count($values);


### PR DESCRIPTION
[[ENG-2421]]

What:
- only set the `$dataType` to `'num'` when ALL values are numeric

Why:
- if one of the values is non-numeric, we need `$dataType` to be `'str'`
- atm, it only checks the first value for numeric-non-numeric behavior
  - for radio select question slides, if the first value is `'1'`, then `$dataType` gets set to `'num'` and then later the `'B/M'` key breaks the pptx.

[ENG-2421]: https://ethisphere.atlassian.net/browse/ENG-2421?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ