### PR TITLE
infra: DSO-953 team-based CODEOWNERS reviewer routing

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -4,5 +4,6 @@
 *           @ethisphere-dev/laravel-lead
 
 # Claude / Spec-Kit harness
+CLAUDE.md   @ethisphere-dev/ai-lead
 .claude/    @ethisphere-dev/ai-lead
 .specify/   @ethisphere-dev/ai-lead

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,8 +1,8 @@
-# Direct-username reviewer routing. Owners are auto-REQUESTED, not required
+# Team-based reviewer routing. Owners are auto-REQUESTED, not required
 # (merge gate is >=1 approval). See ai-toolkit/docs/codeowners-and-routing.md.
 
-*           @LilyEssence
+*           @ethisphere-dev/laravel-lead
 
 # Claude / Spec-Kit harness
-.claude/    @LilyEssence
-.specify/   @LilyEssence
+.claude/    @ethisphere-dev/ai-lead
+.specify/   @ethisphere-dev/ai-lead

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -7,3 +7,8 @@
 CLAUDE.md   @ethisphere-dev/ai-lead
 .claude/    @ethisphere-dev/ai-lead
 .specify/   @ethisphere-dev/ai-lead
+
+# platform + security
+/.github/     @ethisphere-dev/devops
+.dockerignore @ethisphere-dev/devops
+Dockerfile    @ethisphere-dev/devops

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,5 +1,5 @@
 # Team-based reviewer routing. Owners are auto-REQUESTED, not required
-# (merge gate is >=1 approval). See ai-toolkit/docs/codeowners-and-routing.md.
+# (merge gate is >=1 approval). See ../../ai-toolkit/docs/codeowners-and-routing.md.
 
 *           @ethisphere-dev/laravel-lead
 

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,8 @@
+# Direct-username reviewer routing. Owners are auto-REQUESTED, not required
+# (merge gate is >=1 approval). See ai-toolkit/docs/codeowners-and-routing.md.
+
+*           @LilyEssence
+
+# Claude / Spec-Kit harness
+.claude/    @LilyEssence
+.specify/   @LilyEssence


### PR DESCRIPTION
[DSO-953 Fresh refresh of CODEOWNERS to team-based reviewer routing across all repos](https://ethisphere.atlassian.net/browse/DSO-953)

## Feature Behavior

Review requests on this repo now auto-route to GitHub team handles instead of individual usernames.

## Technical Work

- Route the catch-all `*` -> `@ethisphere-dev/laravel-lead`.
- Route the AI harness (`CLAUDE.md`, `.claude/`, `.specify/`) -> `@ethisphere-dev/ai-lead`.
- Part of the org-wide DSO-953 rollout; convention in ai-toolkit/docs/codeowners-and-routing.md.