### PR TITLE
docs: document frozen-fork status in CLAUDE.md and README

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,6 +2,16 @@
 
 PHP library for reading and writing presentation files (PPTX, ODP).
 
+## Fork status: frozen
+
+This is a **frozen fork** of [`PHPOffice/PHPPresentation`](https://github.com/PHPOffice/PHPPresentation), intentionally kept on a ~2023-era base (roughly 100+ commits behind upstream's tip). Do not try to sync it to upstream as routine maintenance.
+
+- **Why it was forked:** chart bugs the upstream maintainer wasn't merging at the time (axis min/max bounds = 0, mixed numeric/string series values, default axis format code), plus a Lato default-font change that worked around not being able to set the font from the ECA app.
+- **Why those reasons are mostly gone:** as of 2026-06 every one of those bugs is fixed upstream (the bounds fix is our own upstream PR [#771](https://github.com/PHPOffice/PHPPresentation/pull/771)). The only genuinely fork-unique change left is the **Lato default font** in `src/PhpPresentation/Style/Font.php` (Calibri -> Lato).
+- **Why it stays frozen:** ECA is largely on ice, so the cost of regression-testing the consuming app against a library ~3 years newer has no payoff. We accept staying on the 2023 base.
+
+**If ECA comes back and an upgrade is wanted**, do not do a 3-way merge from upstream (it conflicts in every patched file). Instead: branch off `develop`, replace the whole tree wholesale with upstream's tip, then re-apply the Lato default on top. That branch descends from `develop`, so it merges conflict-free with no manual resolution.
+
 ## Commands
 
 | Task | Command |

--- a/README.md
+++ b/README.md
@@ -1,3 +1,14 @@
+> ## Ethisphere fork notice (frozen)
+>
+> This is a **frozen fork** of [`PHPOffice/PHPPresentation`](https://github.com/PHPOffice/PHPPresentation), held on a ~2023-era base. It is not kept in sync with upstream.
+>
+> - **Forked for:** chart bugs upstream wasn't merging at the time (axis min/max bounds = 0, mixed numeric/string series values, default axis format code) and a Lato default-font change that worked around not being able to set the font from the ECA app.
+> - **Current state:** as of 2026-06 those bugs are all fixed upstream (the bounds fix is our own upstream PR [#771](https://github.com/PHPOffice/PHPPresentation/pull/771)). The only fork-unique change left is the Lato default font in `src/PhpPresentation/Style/Font.php`.
+> - **Why frozen:** ECA is largely on ice; regression-testing the app against a library ~3 years newer has no payoff. We accept staying on the 2023 base.
+> - **To upgrade later:** don't 3-way merge from upstream (conflicts everywhere). Branch off `develop`, replace the tree wholesale with upstream's tip, then re-apply the Lato default on top (conflict-free, since the branch descends from `develop`).
+>
+> Everything below is the upstream project's original README.
+
 # ![PHPPresentation](https://raw.githubusercontent.com/mvargasmoran/PHPPresentation/develop/docs/images/PHPPresentationLogo.png "PHPPresentation")
 
 [![Latest Stable Version](https://poser.pugx.org/phpoffice/phppresentation/v/stable.png)](https://packagist.org/packages/phpoffice/phppresentation)


### PR DESCRIPTION
## What

Adds a frozen-fork notice to `README.md` (prepended above the upstream readme, which is preserved verbatim) and a "Fork status: frozen" section to `CLAUDE.md`.

## Why

So anyone landing in the repo immediately understands this is a deliberately frozen fork of `PHPOffice/PHPPresentation`, why it was forked, that the bugs are now fixed upstream (the bounds fix is our own upstream PR #771), why it stays frozen while ECA is iced, and the conflict-free path to upgrade if that changes.

Docs-only; no code or behavior changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
